### PR TITLE
fix: PDV 55 add ProvisionedThroughputExceededException handling

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -31,13 +31,13 @@
             "format" : "uuid"
           }
         }, {
-          "name": "namespace",
-          "in": "query",
-          "description": "Namespace",
-          "required": true,
-          "style": "form",
-          "schema": {
-            "type": "string"
+          "name" : "namespace",
+          "in" : "query",
+          "description" : "Namespace",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
           }
         } ],
         "responses" : {
@@ -86,52 +86,46 @@
     },
     "/people/{id}" : {
       "get" : {
-        "tags": [
-          "person"
-        ],
-        "summary": "Find person",
-        "description": "Retrieve the person by its id, if a namespace is present then the id will be interpreted as namespaced id, otherwise as internal (global) id",
-        "operationId": "findByIdUsingGET",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Person internal id",
-            "required": true,
-            "style": "simple",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "isNamespaced",
-            "in": "query",
-            "description": "Indicates if the Person is namespaced or not",
-            "required": true,
-            "style": "form",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "namespace",
-            "in": "query",
-            "description": "Namespace",
-            "required": false,
-            "style": "form",
-            "schema": {
-              "type": "string"
-            }
+        "tags" : [ "person" ],
+        "summary" : "Find person",
+        "description" : "Retrieve the person by its id, if a namespace is present then the id will be interpreted as namespaced id, otherwise as internal (global) id",
+        "operationId" : "findByIdUsingGET",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "Person internal id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string",
+            "format" : "uuid"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PersonResource"
+        }, {
+          "name" : "isNamespaced",
+          "in" : "query",
+          "description" : "Indicates if the Person is namespaced or not",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "namespace",
+          "in" : "query",
+          "description" : "Namespace",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PersonResource"
                 }
               }
             }
@@ -278,39 +272,36 @@
         "summary" : "Upsert person namespace",
         "description" : "Create a new person namespace given its internal (global) id, if already exists do nothing",
         "operationId" : "saveNamespacedIdUsingPUT",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Person internal id",
-            "required": true,
-            "style": "simple",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Namespace",
-            "required": true,
-            "style": "simple",
-            "schema": {
-              "type": "string"
-            }
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "Person internal id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string",
+            "format" : "uuid"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SavePersonNamespaceDto"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Namespace",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SavePersonNamespaceDto"
               }
             }
           }
         },
-        "responses": {
+        "responses" : {
           "204" : {
             "description" : "No Content"
           },
@@ -341,39 +332,36 @@
         "summary" : "Delete person namespace",
         "description" : "Delete person namespace by internal (global) id",
         "operationId" : "deletePersonNamespaceUsingDELETE",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Person internal id",
-            "required": true,
-            "style": "simple",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Namespace",
-            "required": true,
-            "style": "simple",
-            "schema": {
-              "type": "string"
-            }
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "Person internal id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string",
+            "format" : "uuid"
           }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
+        }, {
+          "name" : "namespace",
+          "in" : "path",
+          "description" : "Namespace",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
                 }
               }
             }

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -71,6 +71,16 @@
               }
             }
           },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
           "500" : {
             "description" : "Internal Server Error",
             "content" : {
@@ -150,6 +160,16 @@
               }
             }
           },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
           "500" : {
             "description" : "Internal Server Error",
             "content" : {
@@ -184,6 +204,16 @@
           },
           "400" : {
             "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
@@ -245,6 +275,16 @@
           },
           "409" : {
             "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
@@ -315,6 +355,16 @@
               }
             }
           },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
           "500" : {
             "description" : "Internal Server Error",
             "content" : {
@@ -358,6 +408,16 @@
           },
           "400" : {
             "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {

--- a/connector-api/src/main/java/it/pagopa/pdv/person/connector/exception/TooManyRequestsException.java
+++ b/connector-api/src/main/java/it/pagopa/pdv/person/connector/exception/TooManyRequestsException.java
@@ -1,0 +1,8 @@
+package it.pagopa.pdv.person.connector.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(Throwable cause) {
+        super(cause);
+    }
+}
+

--- a/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImpl.java
@@ -77,7 +77,7 @@ public class PersonConnectorImpl implements PersonConnector {
                     .map(Function.identity());
         }
         catch(ProvisionedThroughputExceededException e){
-            throw new TooManyRequestsException(e.getCause());
+            throw new TooManyRequestsException(e);
         }
         log.debug(CONFIDENTIAL_MARKER, "[findById] output = {}", personDetails);
         log.trace("[findById] end");
@@ -110,7 +110,7 @@ public class PersonConnectorImpl implements PersonConnector {
             }
         }
         catch(ProvisionedThroughputExceededException e){
-            throw new TooManyRequestsException(e.getCause());
+            throw new TooManyRequestsException(e);
         }
         log.debug("[findIdByNamespacedId] output = {}", id);
         log.trace("[findIdByNamespacedId] end");
@@ -129,7 +129,7 @@ public class PersonConnectorImpl implements PersonConnector {
             log.debug("A PersonId with the given primary key already exists");
         }
         catch(ProvisionedThroughputExceededException e){
-            throw new TooManyRequestsException(e.getCause());
+            throw new TooManyRequestsException(e);
         }
         log.trace("[save] end");
     }
@@ -170,7 +170,7 @@ public class PersonConnectorImpl implements PersonConnector {
                         .map(personFound -> (RuntimeException) new UpdateNotAllowedException())
                         .orElseGet(ResourceNotFoundException::new);
             } catch(ProvisionedThroughputExceededException e){
-                throw new TooManyRequestsException(e.getCause());
+                throw new TooManyRequestsException(e);
             } catch (AmazonDynamoDBException e) {
                 if ("ValidationException".equals(e.getErrorCode())) {
                     // create tree parent nodes
@@ -304,7 +304,7 @@ public class PersonConnectorImpl implements PersonConnector {
         } catch (ConditionalCheckFailedException e) {
             throw new ResourceNotFoundException();
         } catch(ProvisionedThroughputExceededException e){
-            throw new TooManyRequestsException(e.getCause());
+            throw new TooManyRequestsException(e);
         }
         log.trace("[deleteById] end");
     }
@@ -323,7 +323,7 @@ public class PersonConnectorImpl implements PersonConnector {
             personIdTableMapper.delete(personId);
         }
         catch(ProvisionedThroughputExceededException e){
-            throw new TooManyRequestsException(e.getCause());
+            throw new TooManyRequestsException(e);
         }
         log.trace("[deleteById] end");
     }

--- a/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspect.java
+++ b/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspect.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ConnectorExceptionHandlingAspect {
 
-    @AfterThrowing(pointcut = "execution(* it.pagopa.pdv.person.connector.dao.*.*(..))", throwing = "ex")
+    @AfterThrowing(pointcut = "execution(public * it.pagopa.pdv.person.connector.dao.PersonConnectorImpl*.*(..))", throwing = "ex")
     public void handleProvisionedThroughputExceededExceptionCall(ProvisionedThroughputExceededException ex){
         log.trace("[ConnectorExceptionHandlingAspect] handleProvisionedThroughputExceededExceptionCall");
         throw new TooManyRequestsException(ex);

--- a/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspect.java
+++ b/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspect.java
@@ -1,0 +1,21 @@
+package it.pagopa.pdv.person.connector.dao.handler;
+
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
+import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class ConnectorExceptionHandlingAspect {
+
+    @AfterThrowing(pointcut = "execution(* it.pagopa.pdv.person.connector.dao.*.*(..))", throwing = "ex")
+    public void handleProvisionedThroughputExceededExceptionCall(ProvisionedThroughputExceededException ex){
+        log.trace("[ConnectorExceptionHandlingAspect] handleProvisionedThroughputExceededExceptionCall");
+        throw new TooManyRequestsException(ex);
+    }
+
+}

--- a/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/DummyConnectorImpl.java
+++ b/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/DummyConnectorImpl.java
@@ -1,0 +1,19 @@
+package it.pagopa.pdv.person.connector.dao;
+
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
+
+
+public class DummyConnectorImpl {
+    public void notThrowingProvisionedThroughputExceededException() {
+
+    }
+
+    public void throwingProvisionedThroughputExceededException() {
+        throw new ProvisionedThroughputExceededException("ProvisionedThroughputExceededException");
+    }
+
+    public void throwingGenericException() throws Exception {
+        throw new Exception("GenericException");
+    }
+
+}

--- a/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImplDummy.java
+++ b/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImplDummy.java
@@ -3,7 +3,7 @@ package it.pagopa.pdv.person.connector.dao;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
 
 
-public class DummyConnectorImpl {
+public class PersonConnectorImplDummy {
     public void notThrowingProvisionedThroughputExceededException() {
 
     }

--- a/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspectTest.java
+++ b/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspectTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.pdv.person.connector.dao.handler;
 
-import it.pagopa.pdv.person.connector.dao.DummyConnectorImpl;
+import it.pagopa.pdv.person.connector.dao.PersonConnectorImplDummy;
 import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -18,12 +18,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @SpringBootTest(classes = {
         ValidationAutoConfiguration.class,
-        DummyConnectorImpl.class,
+        PersonConnectorImplDummy.class,
         ConnectorExceptionHandlingAspect.class})
 @EnableAspectJAutoProxy
 public class ConnectorExceptionHandlingAspectTest {
     @Autowired
-    private DummyConnectorImpl connector;
+    private PersonConnectorImplDummy connector;
 
     @SpyBean
     private ConnectorExceptionHandlingAspect exceptionHandlingAspectSpy;

--- a/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspectTest.java
+++ b/connector/dao/src/test/java/it/pagopa/pdv/person/connector/dao/handler/ConnectorExceptionHandlingAspectTest.java
@@ -1,0 +1,52 @@
+package it.pagopa.pdv.person.connector.dao.handler;
+
+import it.pagopa.pdv.person.connector.dao.DummyConnectorImpl;
+import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@SpringBootTest(classes = {
+        ValidationAutoConfiguration.class,
+        DummyConnectorImpl.class,
+        ConnectorExceptionHandlingAspect.class})
+@EnableAspectJAutoProxy
+public class ConnectorExceptionHandlingAspectTest {
+    @Autowired
+    private DummyConnectorImpl connector;
+
+    @SpyBean
+    private ConnectorExceptionHandlingAspect exceptionHandlingAspectSpy;
+
+    @Test
+    void handleProvisionedThroughputExceededException_throwing(){
+        assertThrows(TooManyRequestsException.class, () -> connector.throwingProvisionedThroughputExceededException());
+        verify(exceptionHandlingAspectSpy, Mockito.times(1))
+                .handleProvisionedThroughputExceededExceptionCall(any());
+        verifyNoMoreInteractions(exceptionHandlingAspectSpy);
+    }
+    @Test
+    void handleProvisionedThroughputExceededException_notThrowing(){
+        assertDoesNotThrow(() -> connector.notThrowingProvisionedThroughputExceededException());
+        verify(exceptionHandlingAspectSpy, Mockito.times(0))
+                .handleProvisionedThroughputExceededExceptionCall(any());
+        verifyNoMoreInteractions(exceptionHandlingAspectSpy);
+    }
+    @Test
+    void handleProvisionedThroughputExceededException_throwingGenericException(){
+        assertThrows(Exception.class, () -> connector.throwingGenericException());
+        verify(exceptionHandlingAspectSpy, Mockito.times(0))
+                .handleProvisionedThroughputExceededExceptionCall(any());
+        verifyNoMoreInteractions(exceptionHandlingAspectSpy);
+    }
+}

--- a/web/src/main/java/it/pagopa/pdv/person/web/config/SwaggerConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/config/SwaggerConfig.java
@@ -62,6 +62,17 @@ class SwaggerConfig {
                                                             .name(Problem.class.getSimpleName()))))))
             .build();
 
+    private static final Response TOO_MANY_REQUESTS_RESPONSE = new ResponseBuilder()
+            .code(String.valueOf(HttpStatus.TOO_MANY_REQUESTS.value()))
+            .description(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase())
+            .representation(MediaType.APPLICATION_PROBLEM_JSON).apply(repBuilder ->
+                    repBuilder.model(modelSpecBuilder ->
+                            modelSpecBuilder.referenceModel(refModelSpecBuilder ->
+                                    refModelSpecBuilder.key(modelKeyBuilder ->
+                                            modelKeyBuilder.qualifiedModelName(qualifiedModelNameBuilder ->
+                                                    qualifiedModelNameBuilder.namespace(Problem.class.getPackageName()).name(Problem.class.getSimpleName()))))))
+            .build();
+
     @Configuration
     @Profile("swaggerIT")
     @PropertySource("classpath:/swagger/swagger_it.properties")
@@ -97,11 +108,11 @@ class SwaggerConfig {
                 .tags(new Tag("person", environment.getProperty("swagger.tag.person.description")))
                 .directModelSubstitute(LocalTime.class, String.class)
                 .useDefaultResponseMessages(false)
-                .globalResponses(HttpMethod.GET, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, NOT_FOUND_RESPONSE))
-                .globalResponses(HttpMethod.DELETE, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE))
-                .globalResponses(HttpMethod.POST, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE))
-                .globalResponses(HttpMethod.PUT, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE))
-                .globalResponses(HttpMethod.PATCH, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE))
+                .globalResponses(HttpMethod.GET, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, NOT_FOUND_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
+                .globalResponses(HttpMethod.DELETE, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
+                .globalResponses(HttpMethod.POST, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
+                .globalResponses(HttpMethod.PUT, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
+                .globalResponses(HttpMethod.PATCH, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
                 .additionalModels(typeResolver.resolve(Problem.class))
                 .forCodeGeneration(true);
     }

--- a/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
@@ -1,6 +1,7 @@
 package it.pagopa.pdv.person.web.handler;
 
 import it.pagopa.pdv.person.connector.exception.ResourceNotFoundException;
+import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
 import it.pagopa.pdv.person.connector.exception.UpdateNotAllowedException;
 import it.pagopa.pdv.person.web.model.Problem;
 import it.pagopa.pdv.person.web.model.mapper.ProblemMapper;
@@ -91,6 +92,12 @@ public class RestExceptionsHandler {
     ResponseEntity<Problem> handleUpdateNotAllowedException(UpdateNotAllowedException e) {
         log.warn(e.toString());
         return ProblemMapper.toResponseEntity(new Problem(CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler({TooManyRequestsException.class})
+    ResponseEntity<Problem> handleTooManyRequestsException(TooManyRequestsException e){
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(TOO_MANY_REQUESTS,e.getMessage()));
     }
 
 }

--- a/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.pdv.person.web.handler;
 
 import it.pagopa.pdv.person.connector.exception.ResourceNotFoundException;
+import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
 import it.pagopa.pdv.person.connector.exception.UpdateNotAllowedException;
 import it.pagopa.pdv.person.web.model.Problem;
 import org.junit.jupiter.api.Test;
@@ -166,6 +167,23 @@ class RestExceptionsHandlerTest {
         assertNotNull(responseEntity.getBody());
         assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
         assertEquals(CONFLICT.value(), responseEntity.getBody().getStatus());
+    }
+
+    @Test
+    void handleTooManyRequestsException(){
+        // given
+        TooManyRequestsException mockException = Mockito.mock(TooManyRequestsException.class);
+        Mockito.when(mockException.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        // when
+        ResponseEntity<Problem> responseEntity = handler.handleTooManyRequestsException(mockException);
+        // then
+        assertNotNull(responseEntity);
+        assertEquals(TOO_MANY_REQUESTS, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(TOO_MANY_REQUESTS.value(), responseEntity.getBody().getStatus());
+
     }
 
 }


### PR DESCRIPTION
This PR aim is to handle the `ProvisionedThroughputExceededException` from `DynamoDB` by wrapping it with a Custom `TooManyRequestsException`.

The `ProvisionedThroughputExceededException` is thrown when the Provisioned Capacity is exceeded and the DynamoDB retry policy reaches the end with no results.