### PR TITLE
feat: Spring Boot upgrade to 3.1.4

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Build with Maven

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
-          --task-definition pdv-${{ matrix.env_short }}-task-person \          
+          --task-definition pdv-${{ matrix.env_short }}-task-person \
           --query taskDefinition > ./task-definition.json
           echo $(cat ./task-definition.json | jq 'del(
                   .taskDefinitionArn,

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -111,7 +111,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: pdv-${{ matrix.env_short }}-person
+          ECR_REPOSITORY: tokenizer-${{ matrix.env_short }}-ecr
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
@@ -121,7 +121,7 @@ jobs:
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
-          --task-definition pdv-${{ matrix.env_short }}-task-person \
+          --task-definition tokenizer-${{ matrix.env_short }}-task-tokenizer \
           --query taskDefinition > ./task-definition.json
           echo $(cat ./task-definition.json | jq 'del(
                   .taskDefinitionArn,
@@ -138,13 +138,13 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@61b0c00c3743b70987a73a1faf577f0d167d1574
         with:
           task-definition: ./task-definition.json
-          container-name: pdv-${{ matrix.env_short }}-container
+          container-name: tokenizer-${{ matrix.env_short }}-container
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: pdv-${{ matrix.env_short }}-service-person
-          cluster: pdv-${{ matrix.env_short }}-ecs-cluster
+          service: tokenizer-${{ matrix.env_short }}-service-tokenizer
+          cluster: tokenizer-${{ matrix.env_short }}-ecs-cluster
           wait-for-service-stability: true

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -111,7 +111,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: tokenizer-${{ matrix.env_short }}-ecr
+          ECR_REPOSITORY: pdv-${{ matrix.env_short }}-person
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
@@ -121,7 +121,7 @@ jobs:
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
-          --task-definition tokenizer-${{ matrix.env_short }}-task-tokenizer \
+          --task-definition pdv-${{ matrix.env_short }}-task-person \          
           --query taskDefinition > ./task-definition.json
           echo $(cat ./task-definition.json | jq 'del(
                   .taskDefinitionArn,
@@ -138,13 +138,13 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@61b0c00c3743b70987a73a1faf577f0d167d1574
         with:
           task-definition: ./task-definition.json
-          container-name: tokenizer-${{ matrix.env_short }}-container
+          container-name: pdv-${{ matrix.env_short }}-container
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: tokenizer-${{ matrix.env_short }}-service-tokenizer
-          cluster: tokenizer-${{ matrix.env_short }}-ecs-cluster
+          service: pdv-${{ matrix.env_short }}-service-person
+          cluster: pdv-${{ matrix.env_short }}-ecs-cluster
           wait-for-service-stability: true

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       AWS_REGION: eu-south-1
-      AWS_ACCESS_KEY_ID: dummy-key
-      AWS_SECRET_KEY: dummy-secrey-key
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_KEY: dummy
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
     - name: Set up JDK
       uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
     - name: Prepare SonarCloud analysis configuration
       run: >

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre@sha256:789f551fca5e233b1593aee65283d5981b3a82284e15a8cad4c798315188f848
+FROM eclipse-temurin:17-jre-alpine@sha256:839f3208bfc22f17bf57391d5c91d51c627d032d6900a0475228b94e48a8f9b3
 VOLUME /tmp
 COPY target/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -18,9 +18,7 @@ spring:
       - ${APP_PROFILE_LOCAL}
   zipkin:
     enabled: false
-  sleuth:
-    propagation:
-      type: AWS
+
 
 info:
   build:
@@ -29,6 +27,10 @@ info:
     description: "@project.description@"
     version: "@project.version@"
 
+management:
+  sampling:
+    probability: 1.0
+    
 logging:
   level:
     it.pagopa.pdv.person: ${APP_LOG_LEVEL:DEBUG}

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -16,9 +16,6 @@ spring:
       # TO enable specific-language documentations
       - swaggerEN
       - ${APP_PROFILE_LOCAL}
-  zipkin:
-    enabled: false
-
 
 info:
   build:
@@ -28,8 +25,13 @@ info:
     version: "@project.version@"
 
 management:
-  sampling:
-    probability: 1.0
+  tracing:
+    baggage:
+      correlation:
+        fields:
+          - x-amzn-trace-id
+      remote-fields:
+        - x-amzn-trace-id
     
 logging:
   level:

--- a/connector-api/src/test/java/it/pagopa/pdv/person/TestUtils.java
+++ b/connector-api/src/test/java/it/pagopa/pdv/person/TestUtils.java
@@ -4,10 +4,10 @@ import lombok.Value;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.util.StringUtils;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/connector/dao/pom.xml
+++ b/connector/dao/pom.xml
@@ -16,10 +16,6 @@
             <artifactId>aws-java-sdk-dynamodb</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-json</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
             <scope>test</scope>

--- a/core/src/main/resources/logback-spring.xml
+++ b/core/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
                 </else>
             </if>
             <property name="stdout_log_pattern"
-                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
+                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{x-amzn-trace-id:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
             <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
                     <pattern>${stdout_log_pattern}</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.13</version>
+        <version>3.1.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <artifactId>pdv-ms-person</artifactId>
@@ -16,10 +16,10 @@
     <description>Microservice to manage person entity</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud.version>2021.0.8</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -28,6 +28,13 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-tracing-bom</artifactId>
+                <version>${micrometer-tracing.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -65,8 +72,8 @@
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-ui</artifactId>
-                <version>1.7.0</version>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                <version>2.2.0</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder -->
             <dependency>
@@ -78,13 +85,19 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-dynamodb</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
                 <version>1.12.172</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.amazonaws/DynamoDBLocal -->
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>DynamoDBLocal</artifactId>
-                <version>1.15.0</version>
+                <version>2.0.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -148,15 +161,16 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-sleuth</artifactId>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.4.2</version>
         </dependency>
     </dependencies>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
         <dependency>
             <groupId>it.pagopa.pdv</groupId>

--- a/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
@@ -1,10 +1,10 @@
 package it.pagopa.pdv.person.web.config;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Collection;
@@ -30,5 +30,8 @@ class WebConfig implements WebMvcConfigurer {
             interceptors.forEach(registry::addInterceptor);
         }
     }
-
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setUseTrailingSlashMatch(true);
+    }
 }

--- a/web/src/main/java/it/pagopa/pdv/person/web/controller/PersonController.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/controller/PersonController.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/web/src/main/java/it/pagopa/pdv/person/web/filters/BaggageFieldFilter.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/filters/BaggageFieldFilter.java
@@ -1,0 +1,43 @@
+package it.pagopa.pdv.person.web.filters;
+
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+public class BaggageFieldFilter extends OncePerRequestFilter {
+    private Tracer tracer;
+
+    private static final String field = "x-amzn-trace-id";
+
+    private static final String BAGGAGE_SETTING_EXCEPTION = "Exception during baggage field setting";
+
+    BaggageFieldFilter(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            String rawBaggage = tracer.getBaggage(field).get();
+            if (rawBaggage != null) {
+                tracer.createBaggage(field, rawBaggage.replaceAll("=", ":"));
+            }
+        }
+        catch (Exception e) {
+            log.error(BAGGAGE_SETTING_EXCEPTION, e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import javax.servlet.ServletException;
-import javax.validation.ValidationException;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.*;

--- a/web/src/main/java/it/pagopa/pdv/person/web/interceptor/LogRequestInterceptor.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/interceptor/LogRequestInterceptor.java
@@ -4,8 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.List;
 

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/CertifiableFieldResource.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/CertifiableFieldResource.java
@@ -7,8 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Data
 @NoArgsConstructor

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/PersonId.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/PersonId.java
@@ -3,7 +3,7 @@ package it.pagopa.pdv.person.web.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/PersonResource.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/PersonResource.java
@@ -3,7 +3,7 @@ package it.pagopa.pdv.person.web.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/Problem.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/Problem.java
@@ -9,9 +9,9 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
 import java.util.List;
 

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/SavePersonDto.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/SavePersonDto.java
@@ -4,7 +4,7 @@ package it.pagopa.pdv.person.web.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.Map;
 

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/SavePersonNamespaceDto.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/SavePersonNamespaceDto.java
@@ -4,7 +4,7 @@ package it.pagopa.pdv.person.web.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/UserSearchDto.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/UserSearchDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 public class UserSearchDto {

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/WorkContactResource.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/WorkContactResource.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import it.pagopa.pdv.person.connector.model.PersonDetailsOperations;
 import lombok.Data;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @Data
 public class WorkContactResource implements PersonDetailsOperations.WorkContactOperations {

--- a/web/src/main/java/it/pagopa/pdv/person/web/validator/PersonControllerResponseValidator.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/validator/PersonControllerResponseValidator.java
@@ -9,8 +9,8 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import java.util.*;
 
 @Slf4j

--- a/web/src/test/java/it/pagopa/pdv/person/web/controller/DummyModel.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/controller/DummyModel.java
@@ -3,7 +3,7 @@ package it.pagopa.pdv.person.web.controller;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 @NoArgsConstructor
 @AllArgsConstructor

--- a/web/src/test/java/it/pagopa/pdv/person/web/filters/BaggageFieldFilterTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/filters/BaggageFieldFilterTest.java
@@ -1,0 +1,54 @@
+package it.pagopa.pdv.person.web.filters;
+
+import io.micrometer.tracing.Baggage;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class BaggageFieldFilterTest {
+
+    @Test
+    void doFilterInternal_withBaggage() {
+        //given
+        Tracer tracer = Mockito.mock(Tracer.class);
+        Baggage baggage = Mockito.mock(Baggage.class);
+        Mockito.when(tracer.getBaggage("x-amzn-trace-id")).thenReturn(baggage);
+        Mockito.when(baggage.get()).thenReturn("test");
+        BaggageFieldFilter baggageFieldFilter = new BaggageFieldFilter(tracer);
+
+        MockFilterChain mockChain = new MockFilterChain();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+        //then
+
+        assertDoesNotThrow(() -> baggageFieldFilter.doFilter(req, rsp, mockChain));
+
+    }
+
+    @Test
+    void doFilterInternal_withoutBaggage(){
+        //given
+        Tracer tracer = Mockito.mock(Tracer.class);
+        Baggage baggage = Mockito.mock(Baggage.class);
+        Mockito.when(tracer.getBaggage("x-amzn-trace-id")).thenReturn(baggage);
+        Mockito.when(baggage.get()).thenReturn(null);
+        BaggageFieldFilter baggageFieldFilter = new BaggageFieldFilter(tracer);
+
+        MockFilterChain mockChain = new MockFilterChain();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+        //then
+
+        assertDoesNotThrow(() -> baggageFieldFilter.doFilter(req, rsp, mockChain));
+
+    }
+}
+

--- a/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
@@ -18,8 +18,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import javax.servlet.ServletException;
-import javax.validation.ValidationException;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/CertifiableFieldResourceTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/CertifiableFieldResourceTest.java
@@ -3,12 +3,12 @@ package it.pagopa.pdv.person.web.model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/PersonIdTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/PersonIdTest.java
@@ -4,11 +4,11 @@ import it.pagopa.pdv.person.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/PersonResourceTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/PersonResourceTest.java
@@ -3,11 +3,11 @@ package it.pagopa.pdv.person.web.model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/SavePersonNamespaceDtoTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/SavePersonNamespaceDtoTest.java
@@ -4,11 +4,11 @@ import it.pagopa.pdv.person.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/UserSearchDtoTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/UserSearchDtoTest.java
@@ -4,11 +4,11 @@ import it.pagopa.pdv.person.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotBlank;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
This **PR** introduces Spring Boot upgrade from `2.7.13` to **`3.1.4`**.
Some of the most important changes are:
- `JDK` version upgrade from `11` to `17` with subsequently change from `javax` packages to `jakarta`
- `spring-cloud` version upgrade from `2021.0.8` to `2022.0.3` due to Spring Boot upgrade.
- Tracing library migration from `spring-cloud-sleuth` to `micrometer-tracing` due to Spring Boot upgrade.
- New _trace id_ correlation mode with a standard `traceId` propagation (W3C format) plus a custom-field (_baggage_) populated with `x-amzn-trace-id`. A new `OncePerRequestFilter` is added to manage this field.
- Minor code refactoring related to overall framework upgrade.