### PR TITLE
fix: Add custom ExpressionLimitExceededException

### DIFF
--- a/connector-api/src/main/java/it/pagopa/pdv/person/connector/exception/ExpressionLimitExceededException.java
+++ b/connector-api/src/main/java/it/pagopa/pdv/person/connector/exception/ExpressionLimitExceededException.java
@@ -1,0 +1,4 @@
+package it.pagopa.pdv.person.connector.exception;
+
+public class ExpressionLimitExceededException extends RuntimeException {
+}

--- a/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/pdv/person/connector/dao/PersonConnectorImpl.java
@@ -16,6 +16,7 @@ import it.pagopa.pdv.person.connector.PersonConnector;
 import it.pagopa.pdv.person.connector.dao.model.PersonDetails;
 import it.pagopa.pdv.person.connector.dao.model.PersonId;
 import it.pagopa.pdv.person.connector.dao.model.Status;
+import it.pagopa.pdv.person.connector.exception.ExpressionLimitExceededException;
 import it.pagopa.pdv.person.connector.exception.ResourceNotFoundException;
 import it.pagopa.pdv.person.connector.exception.UpdateNotAllowedException;
 import it.pagopa.pdv.person.connector.model.PersonDetailsOperations;
@@ -159,7 +160,12 @@ public class PersonConnectorImpl implements PersonConnector {
                     // create tree parent nodes
                     createParentNodes(primaryKey, missingNodes);
                     // retry failed update
-                    table.updateItem(updateItemSpec);
+                    try{
+                        table.updateItem(updateItemSpec);
+                    }
+                    catch(AmazonDynamoDBException ex){
+                        throw new ExpressionLimitExceededException();
+                    }
                 }
             }
         }

--- a/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandler.java
@@ -1,10 +1,13 @@
 package it.pagopa.pdv.person.web.handler;
 
+import it.pagopa.pdv.person.connector.exception.ExpressionLimitExceededException;
 import it.pagopa.pdv.person.connector.exception.ResourceNotFoundException;
 import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
 import it.pagopa.pdv.person.connector.exception.UpdateNotAllowedException;
 import it.pagopa.pdv.person.web.model.Problem;
 import it.pagopa.pdv.person.web.model.mapper.ProblemMapper;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -17,8 +20,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import jakarta.servlet.ServletException;
-import jakarta.validation.ValidationException;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.*;
@@ -98,6 +99,12 @@ public class RestExceptionsHandler {
     ResponseEntity<Problem> handleTooManyRequestsException(TooManyRequestsException e){
         log.warn(e.toString());
         return ProblemMapper.toResponseEntity(new Problem(TOO_MANY_REQUESTS,e.getMessage()));
+    }
+
+    @ExceptionHandler({ExpressionLimitExceededException.class})
+    ResponseEntity<Problem> handleExpressionLimitExceededException(ExpressionLimitExceededException e){
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(BAD_REQUEST,e.getMessage()));
     }
 
 }

--- a/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/handler/RestExceptionsHandlerTest.java
@@ -1,9 +1,12 @@
 package it.pagopa.pdv.person.web.handler;
 
+import it.pagopa.pdv.person.connector.exception.ExpressionLimitExceededException;
 import it.pagopa.pdv.person.connector.exception.ResourceNotFoundException;
 import it.pagopa.pdv.person.connector.exception.TooManyRequestsException;
 import it.pagopa.pdv.person.connector.exception.UpdateNotAllowedException;
 import it.pagopa.pdv.person.web.model.Problem;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,8 +21,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import jakarta.servlet.ServletException;
-import jakarta.validation.ValidationException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -183,6 +184,23 @@ class RestExceptionsHandlerTest {
         assertNotNull(responseEntity.getBody());
         assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
         assertEquals(TOO_MANY_REQUESTS.value(), responseEntity.getBody().getStatus());
+
+    }
+
+    @Test
+    void handleExpressionLimitExceededException(){
+        // given
+        ExpressionLimitExceededException mockException = Mockito.mock(ExpressionLimitExceededException.class);
+        Mockito.when(mockException.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        // when
+        ResponseEntity<Problem> responseEntity = handler.handleExpressionLimitExceededException(mockException);
+        // then
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(BAD_REQUEST.value(), responseEntity.getBody().getStatus());
 
     }
 


### PR DESCRIPTION
Add custom `ExpressionLimitExceededException` to handle DynamoDB error: _AmazonDynamoDBException: Invalid UpdateExpression: Expression size has exceeded the maximum allowed size_