### PR TITLE
ci: Split deploy job to set more granular permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-      contents: write
+      contents: read
     strategy:
         matrix: ${{ fromJson(needs.build.outputs.matrix) }}
          
@@ -70,18 +70,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Release
-        if: ${{ matrix.environment == 'prod' }}
-        id: release
-        # from https://github.com/cycjimmy/semantic-release-action/commits/main
-        uses: cycjimmy/semantic-release-action@bdd914ff2423e2792c73475f11e8da603182f32d
-        with:
-          semantic_version: 18.0.0
-          extra_plugins: |
-            @semantic-release/release-notes-generator@10.0.3
-            @semantic-release/git@10.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -139,3 +127,27 @@ jobs:
           service: pdv-${{ matrix.env_short }}-service-person
           cluster: pdv-${{ matrix.env_short }}-ecs-cluster
           wait-for-service-stability: true
+
+  release:
+    name: "Create Release"
+    if: ${{ needs.build.outputs.matrix != '' }}
+    needs: [build, deploy]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix: ${{ fromJson(needs.build.outputs.matrix) }}
+    environment: ${{ matrix.environment }}
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Release
+        if: ${{ matrix.environment == 'prod' }}
+        id: release
+        # from https://github.com/cycjimmy/semantic-release-action/commits/main
+        uses: cycjimmy/semantic-release-action@bdd914ff2423e2792c73475f11e8da603182f32d
+        with:
+          semantic_version: 18.0.0
+          extra_plugins: |
+            @semantic-release/release-notes-generator@10.0.3
+            @semantic-release/git@10.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR splits the deploy job of the build-and-deploy.yml workflow to give more granular permissions to release and deploy phase