### PR TITLE
feat: Add AWS ECS plugin for AWS X-Ray tracing

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -24,14 +24,6 @@ info:
     description: "@project.description@"
     version: "@project.version@"
 
-management:
-  tracing:
-    baggage:
-      correlation:
-        fields:
-          - x-amzn-trace-id
-      remote-fields:
-        - x-amzn-trace-id
     
 logging:
   level:

--- a/core/src/main/resources/logback-spring.xml
+++ b/core/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
                 </else>
             </if>
             <property name="stdout_log_pattern"
-                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{x-amzn-trace-id:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
+                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{AWS-XRAY-TRACE-ID:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
             <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
                     <pattern>${stdout_log_pattern}</pattern>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -39,6 +39,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-slf4j</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
@@ -1,6 +1,12 @@
 package it.pagopa.pdv.person.web.config;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
 import com.amazonaws.xray.strategy.jakarta.SegmentNamingStrategy;
+import com.amazonaws.xray.plugins.EC2Plugin;
+import com.amazonaws.xray.plugins.ECSPlugin;
+import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 import jakarta.servlet.Filter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -11,8 +17,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
 import java.util.Collection;
+
 
 @Slf4j
 @Configuration
@@ -42,6 +48,11 @@ class WebConfig implements WebMvcConfigurer {
     @Override
     public void configurePathMatch(PathMatchConfigurer configurer) {
         configurer.setUseTrailingSlashMatch(true);
+    }
+    static {
+        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withPlugin(new ECSPlugin()).withPlugin(new EC2Plugin());
+        builder.withSamplingStrategy(new CentralizedSamplingStrategy());
+        AWSXRay.setGlobalRecorder(builder.build());
     }
     @Bean
     public Filter TracingFilter() {

--- a/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/config/WebConfig.java
@@ -6,6 +6,7 @@ import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
 import com.amazonaws.xray.strategy.jakarta.SegmentNamingStrategy;
 import com.amazonaws.xray.plugins.EC2Plugin;
 import com.amazonaws.xray.plugins.ECSPlugin;
+import com.amazonaws.xray.slf4j.SLF4JSegmentListener;
 import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 import jakarta.servlet.Filter;
 import lombok.extern.slf4j.Slf4j;
@@ -50,10 +51,15 @@ class WebConfig implements WebMvcConfigurer {
         configurer.setUseTrailingSlashMatch(true);
     }
     static {
-        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withPlugin(new ECSPlugin()).withPlugin(new EC2Plugin());
+        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder
+                .standard()
+                .withSegmentListener(new SLF4JSegmentListener(""))
+                .withPlugin(new ECSPlugin())
+                .withPlugin(new EC2Plugin());
         builder.withSamplingStrategy(new CentralizedSamplingStrategy());
         AWSXRay.setGlobalRecorder(builder.build());
     }
+
     @Bean
     public Filter TracingFilter() {
         return new AWSXRayServletFilter(SegmentNamingStrategy.dynamic(this.applicationContext.getId()));


### PR DESCRIPTION
This PR introduces AWS X-Ray ECS plugin in order to enrich informations regarding X-Ray Service Map.

Minor changes includes the removal of baggage field `x-amzn-trace-id` via header propagation which is now directly obtained via AWS X-Ray sdk.