### PR TITLE
fix: PDV 139 Fix workContacts with null return value

### DIFF
--- a/connector-api/src/test/java/it/pagopa/pdv/person/connector/model/DummyCertifiedField.java
+++ b/connector-api/src/test/java/it/pagopa/pdv/person/connector/model/DummyCertifiedField.java
@@ -23,4 +23,9 @@ public class DummyCertifiedField<T> implements CertifiableField<T> {
         }
     }
 
+    @SneakyThrows
+    public DummyCertifiedField() {
+        value = null;
+    }
+
 }

--- a/connector-api/src/test/java/it/pagopa/pdv/person/connector/model/DummyPersonDetails.java
+++ b/connector-api/src/test/java/it/pagopa/pdv/person/connector/model/DummyPersonDetails.java
@@ -28,13 +28,20 @@ public class DummyPersonDetails implements PersonDetailsOperations {
         this.workContacts = Map.of("inst-1", new DummyWorkContact());
     }
 
-
     @Data
     public static class DummyWorkContact implements WorkContactOperations {
         private CertifiableField<String> email;
 
         public DummyWorkContact() {
             this.email = new DummyCertifiedField<>(String.class);
+        }
+    }
+    @Data
+    public static class DummyWorkContactNullValue implements WorkContactOperations {
+        private CertifiableField<String> email;
+
+        public DummyWorkContactNullValue() {
+            this.email = new DummyCertifiedField<>();
         }
     }
 

--- a/web/src/main/java/it/pagopa/pdv/person/web/model/mapper/PersonMapper.java
+++ b/web/src/main/java/it/pagopa/pdv/person/web/model/mapper/PersonMapper.java
@@ -1,5 +1,6 @@
 package it.pagopa.pdv.person.web.model.mapper;
 
+import it.pagopa.pdv.person.connector.model.CertifiableField;
 import it.pagopa.pdv.person.connector.model.PersonDetailsOperations;
 import it.pagopa.pdv.person.connector.model.PersonDto;
 import it.pagopa.pdv.person.connector.model.PersonIdDto;
@@ -93,7 +94,14 @@ public class PersonMapper {
         if (workContactOperations != null) {
             workContactResource = new WorkContactResource();
             if (workContactOperations.getEmail() != null) {
-                workContactResource.setEmail(new CertifiableFieldResource<>(workContactOperations.getEmail()));
+                if(workContactOperations.getEmail().getValue() != null) {
+                    workContactResource.setEmail(new CertifiableFieldResource<>(workContactOperations.getEmail()));
+                }
+                else{
+                    CertifiableField<String> emptyEmail = workContactOperations.getEmail();
+                    emptyEmail.setValue("");
+                    workContactResource.setEmail(new CertifiableFieldResource<>(emptyEmail));
+                }
             }
         }
         return workContactResource;

--- a/web/src/test/java/it/pagopa/pdv/person/web/model/mapper/PersonMapperTest.java
+++ b/web/src/test/java/it/pagopa/pdv/person/web/model/mapper/PersonMapperTest.java
@@ -199,7 +199,6 @@ class PersonMapperTest {
         assertIterableEquals(personDetailsOperations.getWorkContacts().keySet(), model.getWorkContacts().keySet());
     }
 
-
     private void assertCertifiableFieldEquals(CertifiableField<?> expected, CertifiableField<?> actual) {
         assertEquals(expected.getCertification(), actual.getCertification());
         assertEquals(expected.getValue(), actual.getValue());
@@ -220,6 +219,17 @@ class PersonMapperTest {
     void toWorkContactResource_notNull() {
         // given
         PersonDetailsOperations.WorkContactOperations workContactOperations = new DummyPersonDetails.DummyWorkContact();
+        // when
+        WorkContactResource model = PersonMapper.toResource(workContactOperations);
+        // then
+        assertNotNull(model);
+        assertCertifiableFieldEquals(workContactOperations.getEmail(), model.getEmail());
+    }
+
+    @Test
+    void toWorkContactResource_nullValue() {
+        // given
+        PersonDetailsOperations.WorkContactOperations workContactOperations = new DummyPersonDetails.DummyWorkContactNullValue();
         // when
         WorkContactResource model = PersonMapper.toResource(workContactOperations);
         // then


### PR DESCRIPTION
This` PR `includes a fix to a problem which is encountered when a null value is present inside the `WorkContacts.{Object}.Email.Value` object on `DynamoDB`.

In particular, it replaces the `null` value with an empty `string` in order to return a correct `PersonResource` to the upstream service.